### PR TITLE
Update Plugin For PMMP And Improvement.

### DIFF
--- a/src/WorldGuard/EventListener.php
+++ b/src/WorldGuard/EventListener.php
@@ -43,6 +43,10 @@ class EventListener implements Listener {
     const POTIONS = [
         373, 374, 437, 438, 444
     ];
+    
+    const OTHER = [
+        256, 259, 269, 273, 277, 284, 290, 291, 292, 293, 294, 325
+    ];
 
     private $plugin;
 
@@ -98,7 +102,7 @@ class EventListener implements Listener {
                 } else $event->setCancelled(false);
 
                 if ($reg->getFlag("editable") === "false") {
-                    if ($event->getItem()->getId() === Item::FLINT_AND_STEEL) {
+                    if (in_array($event->getItem()->getId(), self::OTHER)) {
                         $player->sendMessage(TF::RED.'You cannot use '.$event->getItem()->getName().'.');
                         $event->setCancelled();
                         return;

--- a/src/WorldGuard/WorldGuard.php
+++ b/src/WorldGuard/WorldGuard.php
@@ -280,7 +280,7 @@ class WorldGuard extends PluginBase {
         return false;
     }
 
-    public function onCommand(CommandSender $issuer, Command $cmd, $label, array $args)
+    public function onCommand(CommandSender $issuer, Command $cmd, string $label, array $args): bool
     {
         switch (strtolower($cmd->getName())) {
             case "region":
@@ -422,5 +422,6 @@ class WorldGuard extends PluginBase {
                 }
                 break;
         }
+        return true;
     }
 }


### PR DESCRIPTION
I Updated The Plugin So It Is Compatible With PMMP.

Shovels And Hoes Can Be Used To Turn Grass to GrassPath Block And Till The Land.
Water And Lava Buckets Can Place Their Contents.
This PR Will Also Prevent These From Happening.

I Have Tested Everything With The Latest Version Of PMMP And It All Works.